### PR TITLE
Update install instructions to remove `@next`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ project as a dependency:
 
 Install with npm:
 ```sh
-npm i fastify@next
+npm i fastify
 ```
 Install with yarn:
 ```sh
-yarn add fastify@next
+yarn add fastify
 ```
 
 ### Example


### PR DESCRIPTION
`@next` will still grab the release candidate, and now that 4.0 stable is out, folks should use that instead.